### PR TITLE
authorization 구현

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -23,7 +23,7 @@ export class AuthService {
       password,
       user.password,
     );
-    if (isPasswordValidated) {
+    if (!isPasswordValidated) {
       throw new UnauthorizedException('패스워드가 다릅니다');
     }
     // sub는 나중에 id로 대체

--- a/backend/src/auth/jwt/jwt.guard.ts
+++ b/backend/src/auth/jwt/jwt.guard.ts
@@ -2,4 +2,4 @@ import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
-export class JwtGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/backend/src/auth/jwt/jwt.payload.ts
+++ b/backend/src/auth/jwt/jwt.payload.ts
@@ -1,0 +1,4 @@
+export type Payload = {
+  email: string;
+  sub: string;
+};

--- a/backend/src/auth/jwt/jwt.strategy.ts
+++ b/backend/src/auth/jwt/jwt.strategy.ts
@@ -1,10 +1,12 @@
+import { UsersService } from 'src/users/users.service';
 import { Strategy, ExtractJwt } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Payload } from './jwt.payload';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(private readonly usersService: UsersService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKey: 'secretKey',
@@ -12,5 +14,14 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload): Promise<any> {}
+  async validate(payload: Payload) {
+    //usersRepository 생기면 password를 제거해서 받아오는 finduserByIdWithoutPassword 를 만들어야함
+    //https://www.inflearn.com/course/%ED%83%84%ED%83%84%ED%95%9C-%EB%B0%B1%EC%97%94%EB%93%9C-%EB%84%A4%EC%8A%A4%ED%8A%B8/unit/83833
+
+    const user = await this.usersService.findOne(payload.email);
+    if (!user) {
+      throw new UnauthorizedException('접근오류');
+    }
+    return user;
+  }
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,7 +1,18 @@
-import { Controller, Get, Body, Patch, Param, Delete } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/jwt/jwt.guard';
+import {
+  Controller,
+  Get,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  Req,
+} from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { Request } from 'express';
 
 @ApiTags('users')
 @Controller('users')
@@ -20,6 +31,20 @@ export class UsersController {
   })
   async findAll() {
     return this.usersService.findAll();
+  }
+
+  @ApiOperation({
+    summary: '현재 유저의 정보를 가져오는 API',
+    description: '현재 로그인된 사용자의 정보를 가져옵니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'GET: Users are successfully gotten.',
+  })
+  @UseGuards(JwtAuthGuard)
+  @Get('/me')
+  async getCurrentUser(@Req() req: Request) {
+    return req.user;
   }
 
   @Get(':id')


### PR DESCRIPTION
#28 

[jwt 검사](https://github.com/chloeeee210/mini-board/commit/326548a40e292f3261d053cf8cae800e8affd283)
검사로직을 만들었습니다. (임시로 email 을 id로 체크 중인데 DB 연결 후 생성되는 id를 payload 의 sub 로 갖게할 것 입니다.)
[fix typo](https://github.com/chloeeee210/mini-board/commit/f952bc8a6034e7ba688410b4dc959658db5237f6)
검사로직에서 !하나가 빠진 걸 고쳤습니다.
JwtGuard -> JwtAuthGuard 로 이름을 바꿨습니다.
[/users/me](https://github.com/chloeeee210/mini-board/commit/2cf0bbbfebbdb4fdfbee3c35edd99ca0db5a0797)
현재 로그인된 유저를 가져옵니다. (mock data의 password는 암호화 되어있지않은 비밀번호가 저장되어있기때문에 새로 register 한 후, 검사해야합니다. 이 부분도 위와 마찬가지로 DB연결 후 수정됩니다.